### PR TITLE
Add number of comments counter

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -48,7 +48,8 @@
 			<h3>Cold</h3>
                         {% for pull in pulls['cold'] %}
                         <p>
-                            <a href="{{ pull['url'] }}">{{ pull['name'] }}</a><br/>
+                        <strong>{{ pull['repo_name'] }}</strong>
+                        <a href="{{ pull['url'] }}">{{ pull['name'] }}</a> <em>({{ pull['author'] }})</em><br/>
                             {{ pull['likes'] }} likes / {{ pull['comments'] }} comments
                         </p>
                         {% endfor %}
@@ -57,7 +58,8 @@
 			<h3>Hot!</h3>
                         {% for pull in pulls['hot'] %}
                         <p>
-                            <a href="{{ pull['url'] }}">{{ pull['name'] }}</a><br/>
+                        <strong>{{ pull['repo_name'] }}</strong>
+                        <a href="{{ pull['url'] }}">{{ pull['name'] }}</a> <em>({{ pull['author'] }})</em><br/>
                             {{ pull['likes'] }} likes / {{ pull['comments'] }} comments
                         </p>
                         {% endfor %}
@@ -67,7 +69,8 @@
 			<h3>Burned</h3>
                         {% for pull in pulls['burned'] %}
                         <p>
-                            <a href="{{ pull['url'] }}">{{ pull['name'] }}</a><br/>
+                        <strong>{{ pull['repo_name'] }}</strong>
+                        <a href="{{ pull['url'] }}">{{ pull['name'] }}</a> <em>({{ pull['author'] }})</em><br/>
                             {{ pull['likes'] }} likes / {{ pull['comments'] }} comments
                         </p>
                         {% endfor %}


### PR DESCRIPTION
Added a counter to show also the number of comments in the pull requests.

It only counts the comments in the pull request itself, not the comments that are directly on the commits. A future improvement will be to read each commit in each pull request and aggregate their comments too.
