### PR TITLE
Configured request retry to avoid Github 500 Internal Server Errors

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,14 +1,25 @@
-# Address where the application listens
-LISTEN_ADDRESS = '0.0.0.0'
+########################
+# Global configuration #
+########################
 
-# Number of days to consider a pull request 'old'
-OLD_DAYS = 2
+LISTEN_ADDRESS = '0.0.0.0'                  # Address where the application listens
+TITLE = 'Abiquo Code Review Dashboard'      # The title to display
+OLD_DAYS = 2                                # Number of days to consider a pull request 'old'
+OK_PATTERNS = ["\+1", ":shoe:\s*:soccer:"]  # The patterns that are considered an OK
 
-# The title to display
-TITLE = 'Abiquo Code Review Dashboard'
+#####################
+# I/O configuration #
+#####################
 
-# The patterns in comments that are considered an OK
-OK_PATTERNS = ["\+1", ":shoe:\s*:soccer:", ":shipit:"]
+DEBUG = True        # Print debut information
+THREADED = True     # Use multiple threads to perform the Github API calls
+MAX_RETRIES = 5     # Number of retries for failed requests
+DELAY = 1           # The default delay (in seconds) to wait before retrying failed requests
+BACKOFF = 2         # The backoff factor to wait between retries
+
+#######################
+# Watch configuration #
+#######################
 
 # The repos to track
 # ORG = 'abiquo'   # Use this to watch all repos of the organization
@@ -22,7 +33,6 @@ REPOS = ["https://api.github.com/repos/abiquo/aim",
          "https://api.github.com/repos/abiquo/commons-amqp",
          "https://api.github.com/repos/abiquo/abiquo-chef-agent",
          "https://api.github.com/repos/abiquo/abiquo-ucs-client",
-         "https://api.github.com/repos/abiquo/jclouds-abiquo",
          "https://api.github.com/repos/abiquo/clientui",
          "https://api.github.com/repos/abiquo/system-properties",
          "https://api.github.com/repos/abiquo/appliance-manager",
@@ -39,6 +49,7 @@ REPOS = ["https://api.github.com/repos/abiquo/aim",
          "https://api.github.com/repos/abiquo/maven-archetypes",
          "https://api.github.com/repos/abiquo/task-service",
          "https://api.github.com/repos/abiquo/jclouds",
+         "https://api.github.com/repos/abiquo/jclouds-labs",
          "https://api.github.com/repos/abiquo/jclouds-chef",
          "https://api.github.com/repos/abiquo/esx-plugin",
          "https://api.github.com/repos/abiquo/hyperv-plugin",
@@ -48,7 +59,6 @@ REPOS = ["https://api.github.com/repos/abiquo/aim",
          "https://api.github.com/repos/abiquo/oraclevm-plugin",
          "https://api.github.com/repos/abiquo/hypervisor-plugin-model",
          "https://api.github.com/repos/abiquo/commons-redis",
-         "https://api.github.com/repos/abiquo/jclouds-labs",
          "https://api.github.com/repos/abiquo/nexenta-plugin",
          "https://api.github.com/repos/abiquo/netapp-plugin",
          "https://api.github.com/repos/abiquo/ec2-plugin",


### PR DESCRIPTION
Improved the dashboard to retry failed requests and allow a single-threaded mode:
- Debug output has been enabled.
- Multi-threading can be now turned off by configuration.
- A backoff based retry has been implemented so failed requests are retried waiting a reasonable amount of time. Retries will wait exponentially until the configured max retries.
  
  ```
  ...
  GET https://api.github.com/repos/abiquo/flex-client-stub/pulls
  GET https://api.github.com/repos/abiquo/flex-client-stub/pulls/71
  GET https://api.github.com/repos/abiquo/flex-client-stub/issues/71/comments
  Request failed. Retrying in 1 seconds
  GET https://api.github.com/repos/abiquo/flex-client-stub/issues/71/comments
  Request failed. Retrying in 2 seconds
  GET https://api.github.com/repos/abiquo/flex-client-stub/issues/71/comments
  ...
  ```
